### PR TITLE
Initialize selectors

### DIFF
--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -42,19 +42,13 @@ __all__ = [
 class Selector(Generic[InputPackType, OutputPackType], Configurable):
     def __init__(self, configs: Optional[Union[Config, Dict[str, Any]]] = None):
         self.configs = self.make_configs(configs)
-        # The flag indicating whether the selector is initialized.
-        self.__is_initialized: bool = False
 
     def select(self, pack: InputPackType) -> Iterator[OutputPackType]:
         raise NotImplementedError
 
     def initialize(self):
         # Reset selector states
-        self.__is_initialized = True
-
-    @property
-    def is_initialized(self) -> bool:
-        return self.__is_initialized
+        pass
 
 
 class DummySelector(Selector[InputPackType, InputPackType]):

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -40,15 +40,16 @@ __all__ = [
 
 
 class Selector(Generic[InputPackType, OutputPackType], Configurable):
-    def __init__(self, configs: Optional[Union[Config, Dict[str, Any]]] = None):
-        self.configs = self.make_configs(configs)
+
+    def __init__(self):
+        self.configs: Config = Config({}, {})
 
     def select(self, pack: InputPackType) -> Iterator[OutputPackType]:
         raise NotImplementedError
 
-    def initialize(self):
-        # Reset selector states
-        pass
+    def initialize(self,
+                   configs: Optional[Union[Config, Dict[str, Any]]] = None):
+        self.configs = self.make_configs(configs)
 
 
 class DummySelector(Selector[InputPackType, InputPackType]):
@@ -78,26 +79,17 @@ class NameMatchSelector(SinglePackSelector):
         selector = NameMatchSelector(select_name="foo")
         selector = NameMatchSelector("foo")
     Now:
-        selector = NameMatchSelector(
+        selector = NameMatchSelector()
+        selector.initialize(
             configs={
                 "select_name": "foo"
             }
         )
     """
 
-    def __init__(self, *args, **kwargs):
-        assert (len(args) == 0) ^ (len(kwargs) == 0)
-        if args:
-            configs = {"select_name": args[0]}
-        else:
-            assert ("configs" in kwargs) or ("select_name" in kwargs)
-            if "select_name" in kwargs:
-                configs = {"select_name": kwargs["select_name"]}
-            else:
-                configs = kwargs["configs"]
-        super().__init__(configs=configs)
-        self.select_name = self.configs["select_name"]
-        assert self.select_name is not None
+    def __init__(self, select_name: str = None):
+        super().__init__()
+        self.select_name = select_name
 
     def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
         matches = 0
@@ -110,6 +102,19 @@ class NameMatchSelector(SinglePackSelector):
             raise ValueError(
                 f"Pack name {self.select_name}" f" not in the MultiPack"
             )
+
+    def initialize(self,
+                   configs: Optional[Union[Config, Dict[str, Any]]] = None):
+        if self.select_name is not None:
+            super().initialize(
+                {"select_name": self.select_name}
+            )
+        else:
+            super().initialize(configs)
+
+        if self.configs["select_name"] is None:
+            raise ValueError("select_name shouldn't be None.")
+        self.select_name = self.configs["select_name"]
 
     @classmethod
     def default_configs(cls):
@@ -124,26 +129,17 @@ class RegexNameMatchSelector(SinglePackSelector):
         selector = RegexNameMatchSelector(select_name="^.*\\d$")
         selector = RegexNameMatchSelector("^.*\\d$")
     Now:
-        selector = RegexNameMatchSelector(
+        selector = RegexNameMatchSelector()
+        selector.initialize(
             configs={
                 "select_name": "^.*\\d$"
             }
         )
     """
 
-    def __init__(self, *args, **kwargs):
-        assert (len(args) == 0) ^ (len(kwargs) == 0)
-        if args:
-            configs = {"select_name": args[0]}
-        else:
-            assert ("configs" in kwargs) or ("select_name" in kwargs)
-            if "select_name" in kwargs:
-                configs = {"select_name": kwargs["select_name"]}
-            else:
-                configs = kwargs["configs"]
-        super().__init__(configs=configs)
-        self.select_name = self.configs["select_name"]
-        assert self.select_name is not None
+    def __init__(self, select_name: str = None):
+        super().__init__()
+        self.select_name = select_name
 
     def select(self, m_pack: MultiPack) -> Iterator[DataPack]:
         if len(m_pack.packs) == 0:
@@ -152,6 +148,19 @@ class RegexNameMatchSelector(SinglePackSelector):
             for name, pack in m_pack.iter_packs():
                 if re.match(self.select_name, name):
                     yield pack
+
+    def initialize(self,
+                   configs: Optional[Union[Config, Dict[str, Any]]] = None):
+        if self.select_name is not None:
+            super().initialize(
+                {"select_name": self.select_name}
+            )
+        else:
+            super().initialize(configs)
+
+        if self.configs["select_name"] is None:
+            raise ValueError("select_name shouldn't be None.")
+        self.select_name = self.configs["select_name"]
 
     @classmethod
     def default_configs(cls):

--- a/forte/data/selector.py
+++ b/forte/data/selector.py
@@ -42,9 +42,19 @@ __all__ = [
 class Selector(Generic[InputPackType, OutputPackType], Configurable):
     def __init__(self, configs: Optional[Union[Config, Dict[str, Any]]] = None):
         self.configs = self.make_configs(configs)
+        # The flag indicating whether the selector is initialized.
+        self.__is_initialized: bool = False
 
     def select(self, pack: InputPackType) -> Iterator[OutputPackType]:
         raise NotImplementedError
+
+    def initialize(self):
+        # Reset selector states
+        self.__is_initialized = True
+
+    @property
+    def is_initialized(self) -> bool:
+        return self.__is_initialized
 
 
 class DummySelector(Selector[InputPackType, InputPackType]):

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -171,6 +171,7 @@ class Pipeline(Generic[PackType]):
         self._components: List[PipelineComponent] = []
         self._selectors: List[Selector] = []
         self._configs: List[Optional[Config]] = []
+        self._selectors_configs: List[Optional[Config]] = []
 
         # Maintain a set of the pipeline components to fast check whether
         # the component is already there.
@@ -210,6 +211,7 @@ class Pipeline(Generic[PackType]):
 
         # Create one copy of the dummy selector to reduce class creation.
         self.__default_selector: Selector = DummySelector()
+        self.__default_selector_config: Config = Config({}, {})
 
         # needed for time profiling of pipeline
         self._enable_profiling: bool = False
@@ -298,6 +300,7 @@ class Pipeline(Generic[PackType]):
                         class_name=selector_config["type"],
                         class_args=selector_config.get("kwargs", {}),
                     ),
+                    selector_config=selector_config.get("configs")
                 )
 
         # Set pipeline states and resources
@@ -387,8 +390,9 @@ class Pipeline(Generic[PackType]):
                 ),
             }
         )
-        for component, config, selector in zip(
-            self.components, self.component_configs, self._selectors
+        for component, config, selector, selector_config in zip(
+            self.components, self.component_configs,
+            self._selectors, self._selectors_configs
         ):
             configs["components"].append(
                 {
@@ -399,14 +403,12 @@ class Pipeline(Generic[PackType]):
                     ),
                     "selector": {
                         "type": get_full_module_name(selector),
-                        "kwargs": {
-                            "configs": test_jsonable(
-                                # pylint: disable=protected-access
-                                test_dict=selector.configs.todict(),
-                                # pylint: enable=protected-access
-                                err_msg=get_err_msg["selector"](selector),
-                            )
-                        },
+                        "configs": test_jsonable(
+                            # pylint: disable=protected-access
+                            test_dict=selector_config.todict(),
+                            # pylint: enable=protected-access
+                            err_msg=get_err_msg["selector"](selector),
+                        ),
                     },
                 }
             )
@@ -678,9 +680,9 @@ class Pipeline(Generic[PackType]):
         """
         This function will reset the states of selectors
         """
-        for selector in self._selectors:
+        for selector, config in zip(self._selectors, self._selectors_configs):
             try:
-                selector.initialize()
+                selector.initialize(config)
             except ValueError as e:
                 logging.error("Exception occur when initializing selectors")
                 raise e
@@ -744,6 +746,7 @@ class Pipeline(Generic[PackType]):
         component: PipelineComponent,
         config: Optional[Union[Config, Dict[str, Any]]] = None,
         selector: Optional[Selector] = None,
+        selector_config: Optional[Union[Config, Dict[str, Any]]] = None,
     ) -> "Pipeline":
         """
         Adds a pipeline component to the pipeline. The pipeline components
@@ -813,8 +816,10 @@ class Pipeline(Generic[PackType]):
 
         if selector is None:
             self._selectors.append(self.__default_selector)
+            self._selectors_configs.append(self.__default_selector_config)
         else:
             self._selectors.append(selector)
+            self._selectors_configs.append(selector.make_configs(selector_config))
 
         return self
 

--- a/forte/pipeline.py
+++ b/forte/pipeline.py
@@ -613,8 +613,9 @@ class Pipeline(Generic[PackType]):
         else:
             self.reader.enforce_consistency(enforce=False)
 
-        # Handle other components.
+        # Handle other components and their selectors.
         self.initialize_components()
+        self.initialize_selectors()
         self._initialized = True
 
         # Create profiler
@@ -672,6 +673,17 @@ class Pipeline(Generic[PackType]):
                 raise e
 
             component.enforce_consistency(enforce=self._check_type_consistency)
+
+    def initialize_selectors(self):
+        """
+        This function will reset the states of selectors
+        """
+        for selector in self._selectors:
+            try:
+                selector.initialize()
+            except ValueError as e:
+                logging.error("Exception occur when initializing selectors")
+                raise e
 
     def set_reader(
         self,

--- a/tests/forte/advanced_pipeline_test.py
+++ b/tests/forte/advanced_pipeline_test.py
@@ -190,11 +190,10 @@ class AdvancedPipelineTest(unittest.TestCase):
         pl.set_reader(DummyMultiPackReader())
         pl.add(
             DummyProcessor(),
-            selector=RegexNameMatchSelector(
-                configs={
-                    "select_name": "^.*\\d$"
-                }
-            )
+            selector=RegexNameMatchSelector(),
+            selector_config={
+                "select_name": "^.*\\d$"
+            },
         )
         pl.save(self._pl_config_path)
 

--- a/tests/forte/data/selector_test.py
+++ b/tests/forte/data/selector_test.py
@@ -39,10 +39,11 @@ class SelectorTest(unittest.TestCase):
         data_pack3.pack_name = "Three"
 
     def test_name_match_selector(self) -> None:
-        selector = NameMatchSelector(
+        selector = NameMatchSelector()
+        selector.initialize(
             configs={
                 "select_name": "pack1"
-            }
+            },
         )
         packs = selector.select(self.multi_pack)
         doc_ids = ["1"]
@@ -63,10 +64,11 @@ class SelectorTest(unittest.TestCase):
             self.assertEqual(doc_id, pack.pack_name)
 
     def test_regex_name_match_selector(self) -> None:
-        selector = RegexNameMatchSelector(
+        selector = RegexNameMatchSelector()
+        selector.initialize(
             configs={
                 "select_name": "^.*\\d$"
-            }
+            },
         )
         packs = selector.select(self.multi_pack)
         doc_ids = ["1", "2"]

--- a/tests/forte/pipeline_test.py
+++ b/tests/forte/pipeline_test.py
@@ -699,11 +699,10 @@ class MultiPackPipelineTest(unittest.TestCase):
         nlp.add(
             DummyRelationExtractor(),
             config={"batcher": {"batch_size": 5}},
-            selector=NameMatchSelector(
-                configs={
-                    "select_name": pack_name
-                }
-            )
+            selector=NameMatchSelector(),
+            selector_config={
+                "select_name": pack_name
+            },
         )
         nlp.initialize()
 
@@ -1303,11 +1302,10 @@ class RecordCheckPipelineTest(unittest.TestCase):
         nlp.add(
             dummy,
             config={"test": "dummy1"},
-            selector=NameMatchSelector(
-                configs={
-                    "select_name": "default"
-                }
-            )
+            selector=NameMatchSelector(),
+            selector_config={
+                "select_name": "default"
+            },
         )
 
         # This will not add the component successfully because the processor is
@@ -1316,12 +1314,12 @@ class RecordCheckPipelineTest(unittest.TestCase):
             nlp.add(dummy, config={"test": "dummy2"})
 
         # This will add the component, with a different selector
-        nlp.add(dummy,
-             selector=NameMatchSelector(
-                configs={
-                    "select_name": "copy"
-                }
-            )
+        nlp.add(
+            dummy,
+            selector=NameMatchSelector(),
+            selector_config={
+                "select_name": "copy"
+            },
         )
         nlp.initialize()
 


### PR DESCRIPTION
This PR mainly addresses this [comment](https://github.com/asyml/forte/pull/499#discussion_r708484962). 

### Description of changes
- Add an `initialize` method to `Selector`.
- Add an `initialize_selectors` method to `Pipeline`, which calls `initialize` for each selector in the pipeline.
- Add a new field `_selector_configs` to `Pipeline` to store selector configs.
- During initialization, a pipeline calls `initialize_selectors` right after it finishes `initialize_components`.

### Possible influences of this PR.
Users now need to set up selector config correctly by calling `selector`'s `initialize` method, which is more similar to what `PipelineComponent` does.
Backward compatibility is assured.

### Test Conducted
This PR passed unit tests in: 
- `tests/forte/pipeline_test.py`
- `tests/forte/advanced_pipeline_test.py`
- `tests/forte/data/selector_test.py`
